### PR TITLE
feat: add configurable query result size limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ LOG_COLORS=true                            # Override: force colors on/off (auto
 RATE_LIMIT_WINDOW_MS=900000                # Time window in ms (default: 900000 = 15 minutes)
 RATE_LIMIT_MAX_REQUESTS=100                # Max requests per window (default: 100)
 RATE_LIMIT_ENABLED=true                    # Set to 'false' to disable (default: true)
+
+# Optional - Query Limits
+QUERY_DEFAULT_LIMIT=1000                   # Default rows returned (default: 1000)
+QUERY_MAX_LIMIT=10000                      # Maximum rows allowed (default: 10000)
 ```
 
 ### Environment Variables
@@ -110,6 +114,8 @@ RATE_LIMIT_ENABLED=true                    # Set to 'false' to disable (default:
 | `RATE_LIMIT_WINDOW_MS` | No | `900000` | Rate limit time window in milliseconds (15 min) |
 | `RATE_LIMIT_MAX_REQUESTS` | No | `100` | Maximum requests allowed per window |
 | `RATE_LIMIT_ENABLED` | No | `true` | Set to `false` or `0` to disable rate limiting |
+| `QUERY_DEFAULT_LIMIT` | No | `1000` | Default number of rows returned by queries |
+| `QUERY_MAX_LIMIT` | No | `10000` | Maximum rows allowed (caps user-provided limits) |
 
 *Either the environment variable or the corresponding `*_FILE` variable must be set. File-based secrets take priority when both are provided.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -243,3 +243,54 @@ export const DEFAULT_RATE_LIMIT: RateLimitConfig = {
   maxRequests: 100,
   enabled: true,
 };
+
+/**
+ * Query limit configuration interface
+ */
+export interface QueryLimitConfig {
+  /** Default number of rows to return (default: 1000) */
+  defaultLimit: number;
+  /** Maximum number of rows allowed (default: 10000) */
+  maxLimit: number;
+}
+
+/**
+ * Default query limit configuration values
+ *
+ * Environment variables:
+ * - QUERY_DEFAULT_LIMIT: Default rows to return (default: 1000)
+ * - QUERY_MAX_LIMIT: Maximum rows allowed, caps user-provided limits (default: 10000)
+ */
+export const DEFAULT_QUERY_LIMIT: QueryLimitConfig = {
+  defaultLimit: 1000,
+  maxLimit: 10000,
+};
+
+/**
+ * Get query limit configuration from environment variables
+ */
+export function getQueryLimitConfig(): QueryLimitConfig {
+  const defaultLimit = parseInt(process.env.QUERY_DEFAULT_LIMIT || '1000', 10);
+  const maxLimit = parseInt(process.env.QUERY_MAX_LIMIT || '10000', 10);
+
+  return {
+    defaultLimit: Math.max(1, defaultLimit),
+    maxLimit: Math.max(1, maxLimit),
+  };
+}
+
+/**
+ * Apply query limit constraints.
+ * Returns the effective limit, capped to maxLimit.
+ *
+ * @param requestedLimit - The limit requested by the user (or undefined for default)
+ * @param config - Query limit configuration
+ * @returns The effective limit to use
+ */
+export function applyQueryLimit(
+  requestedLimit: number | undefined,
+  config: QueryLimitConfig = getQueryLimitConfig()
+): number {
+  const limit = requestedLimit ?? config.defaultLimit;
+  return Math.min(Math.max(1, limit), config.maxLimit);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -102,14 +102,14 @@ export function createServer(): McpServer {
       inputSchema: {
         sql: z.string().describe('SQL SELECT query to execute'),
         params: z.array(z.unknown()).optional().describe('Query parameters for prepared statement'),
-        limit: z.number().optional().default(1000).describe('Maximum number of rows to return (default: 1000)'),
+        limit: z.number().optional().default(1000).describe('Maximum number of rows to return (default: 1000, max: configured via QUERY_MAX_LIMIT)'),
       },
     },
     withToolHandler(
       (args) => executeQueryTool({
         sql: args.sql,
         params: args.params,
-        limit: args.limit ?? 1000,
+        limit: args.limit,
       }),
       'Query failed'
     )


### PR DESCRIPTION
## Summary

Add configurable maximum query result limits to prevent memory exhaustion from excessively large result sets.

## Related Issues

- Closes #14
- Addresses medium issue 4 from security review #8

## Changes

### Config Module (`src/config.ts`)
- Add `QueryLimitConfig` interface
- Add `DEFAULT_QUERY_LIMIT` constants (default: 1000, max: 10000)
- Add `getQueryLimitConfig()` to read from env vars
- Add `applyQueryLimit()` to cap user-provided limits

### Query Tool (`src/tools/query.ts`)
- Use `applyQueryLimit()` to enforce maximum
- Return `limitApplied` in response for transparency
- Log both requested and effective limits

### Server (`src/server.ts`)
- Update tool description to mention max limit

### Documentation (`README.md`)
- Add `QUERY_DEFAULT_LIMIT` and `QUERY_MAX_LIMIT` to env vars table

### Tests (`tests/config.test.ts`)
- Add tests for `getQueryLimitConfig()`
- Add tests for `applyQueryLimit()` including edge cases

## Behavior

| Requested Limit | Effective Limit (max=10000) |
|-----------------|----------------------------|
| undefined | 1000 (default) |
| 500 | 500 |
| 20000 | 10000 (capped) |
| 0 | 1 (minimum) |
| -100 | 1 (minimum) |